### PR TITLE
Create index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ function base64Decode(x) {
 //   http://www.ecma-international.org/ecma-262/6.0/index.html#sec-quotejsonstring
 //   DO: 2.a -> 2.b -> 2.c -> 2.d
 var escapeJavaScriptTable = {
-  '"': '\"',    // 2.a
+   '"': '\\"',    // 2.a
   '\\': '\\\\',
   '\b': '\\b',  // 2.b (skip abbrev)
   '\f': '\\f',


### PR DESCRIPTION
ref: https://github.com/ToQoz/api-gateway-mapping-template/issues/8

double quote the string used in `util.escapeJsonString`.

Note, I notice the existing test - https://github.com/jlongman/api-gateway-mapping-template/blob/master/test/util.js#L5 - this would presumably break this test? I may add the test in the original issue to the PR.

Thinking about this, maybe this suggests a difference in runtime environments?  Will add notes to the issue.